### PR TITLE
Fix usage of string formatting in HTTPError

### DIFF
--- a/pypiserver/_app.py
+++ b/pypiserver/_app.py
@@ -174,9 +174,7 @@ def file_upload():
     ):
         raise HTTPError(
             400,
-            "Unrelated signature %r for package %r!",
-            ufiles.sig,
-            ufiles.pkg,
+            "Unrelated signature %r for package %r!" % (ufiles.sig, ufiles.pkg)
         )
 
     for uf in ufiles:
@@ -197,8 +195,8 @@ def file_upload():
             raise HTTPError(
                 409,
                 "Package %r already exists!\n"
-                "  You may start server with `--overwrite` option.",
-                uf.raw_filename,
+                "  You may start server with `--overwrite` option."
+                % uf.raw_filename,
             )
 
         core.store(packages.root, uf.raw_filename, uf.save)


### PR DESCRIPTION
A couple cases where the error message provided to HTTPError is given format args separately rather than applying the formatting directly. This results in error messages for the user like this, where the package is not shown:

    <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
    <html>
        <head>
            <title>Error: 409 Conflict</title>
            <style type="text/css">
              html {background-color: #eee; font-family: sans-serif;}
              body {background-color: #fff; border: 1px solid #ddd;
                    padding: 15px; margin: 15px;}
              pre {background-color: #eee; border: 1px solid #ddd; padding: 5px;}
            </style>
        </head>
        <body>
            <h1>Error: 409 Conflict</h1>
            <p>Sorry, the requested URL <tt>&#039;http://pypiserver/&#039;</tt>
               caused an error:</p>
            <pre>Package %r already exists!
              You may start server with `--overwrite` option.</pre>
        </body>
    </html>

`HTTPError(code, message, format_args)` appears to be equivalent to `HTTPError(status=code, body=message, exception=format_args)` which is not what we want here. The string formatting can't be deferred like in logging library usage.